### PR TITLE
fix: Maven publication validation for non-SNAPSHOT versions

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -251,15 +251,20 @@ jobs:
         run: |
           echo "Locating detekt-rules-koin artifacts in local Maven repository..."
 
-          ARTIFACTS_DIR="$(find "$HOME/.m2/repository" -type d -path "*/io/github/krozov/detekt-rules-koin/*" -name "*SNAPSHOT" | head -n 1)"
+          # Get version from Gradle
+          VERSION=$(./gradlew properties --no-daemon --console=plain -q | grep "^version:" | awk '{print $2}')
+          echo "Project version: $VERSION"
+
+          ARTIFACTS_DIR="$HOME/.m2/repository/io/github/krozov/detekt-rules-koin/$VERSION"
 
           if [ -z "$ARTIFACTS_DIR" ] || [ ! -d "$ARTIFACTS_DIR" ]; then
-            echo "❌ Could not locate detekt-rules-koin artifacts in local Maven repository"
+            echo "❌ Could not locate detekt-rules-koin artifacts at: $ARTIFACTS_DIR"
+            echo "Searching for any version..."
+            find "$HOME/.m2/repository/io/github/krozov" -type d 2>/dev/null || true
             exit 1
           fi
 
-          VERSION="$(basename "$ARTIFACTS_DIR")"
-          echo "✅ Found version: $VERSION"
+          echo "✅ Found artifacts at: $ARTIFACTS_DIR"
 
           echo "Checking for required artifacts..."
 


### PR DESCRIPTION
## Problem

Maven publication validation was failing with:
```
❌ Could not locate detekt-rules-koin artifacts in local Maven repository
```

## Root Cause

The workflow used `find` with pattern `*SNAPSHOT` to locate artifacts:
```bash
ARTIFACTS_DIR="$(find "$HOME/.m2/repository" -type d -path "*/io/github/krozov/detekt-rules-koin/*" -name "*SNAPSHOT" | head -n 1)"
```

But the actual project version is `0.1.0` (without SNAPSHOT suffix), so the pattern never matched.

## Solution

Changed to get version dynamically from Gradle:
```bash
VERSION=$(./gradlew properties --no-daemon --console=plain -q | grep "^version:" | awk '{print $2}')
ARTIFACTS_DIR="$HOME/.m2/repository/io/github/krozov/detekt-rules-koin/$VERSION"
```

## Benefits

- ✅ Works with both SNAPSHOT and release versions
- ✅ More robust - uses exact version from Gradle
- ✅ Better error messages with diagnostic output
- ✅ No fragile wildcard matching

## Testing

Verified locally:
```
Version: 0.1.0
✅ Found 3 JARs: main, sources, javadoc
```

## Fixes

This fix is required for PR #6 (Kover integration) to pass CI checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)