### PR TITLE
fix: allow androidContext() inside module definitions

### DIFF
--- a/src/test/kotlin/io/github/krozov/detekt/koin/platform/android/AndroidContextNotFromKoinTest.kt
+++ b/src/test/kotlin/io/github/krozov/detekt/koin/platform/android/AndroidContextNotFromKoinTest.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test
 class AndroidContextNotFromKoinTest {
 
     @Test
-    fun `reports androidContext in module definition`() {
+    fun `allows androidContext in module definition`() {
         val code = """
             val myModule = module {
                 single { androidContext() }
@@ -16,11 +16,7 @@ class AndroidContextNotFromKoinTest {
         """.trimIndent()
 
         val findings = AndroidContextNotFromKoin(Config.empty).lint(code)
-
-        assertThat(findings).hasSize(1)
-        assertThat(findings[0].message).contains("→")
-        assertThat(findings[0].message).contains("✗ Bad")
-        assertThat(findings[0].message).contains("✓ Good")
+        assertThat(findings).isEmpty()
     }
 
     @Test
@@ -41,12 +37,111 @@ class AndroidContextNotFromKoinTest {
     }
 
     @Test
-    fun `reports androidApplication outside startKoin`() {
+    fun `reports androidApplication outside Koin context`() {
         val code = """
             val context = androidApplication()
         """.trimIndent()
 
         val findings = AndroidContextNotFromKoin(Config.empty).lint(code)
         assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `reports androidContext outside Koin context`() {
+        val code = """
+            fun setup() {
+                val ctx = androidContext()
+            }
+        """.trimIndent()
+
+        val findings = AndroidContextNotFromKoin(Config.empty).lint(code)
+        assertThat(findings).hasSize(1)
+        assertThat(findings[0].message).contains("outside Koin context")
+        assertThat(findings[0].message).contains("✗ Bad")
+        assertThat(findings[0].message).contains("✓ Good")
+    }
+
+    @Test
+    fun `allows androidContext inside single block in module`() {
+        val code = """
+            val myModule = module {
+                single { MyRepository(androidContext()) }
+            }
+        """.trimIndent()
+
+        val findings = AndroidContextNotFromKoin(Config.empty).lint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `allows androidContext inside factory block in module`() {
+        val code = """
+            val myModule = module {
+                factory { MyService(androidContext()) }
+            }
+        """.trimIndent()
+
+        val findings = AndroidContextNotFromKoin(Config.empty).lint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `allows androidContext inside scoped block in module`() {
+        val code = """
+            val myModule = module {
+                scoped { MyManager(androidContext()) }
+            }
+        """.trimIndent()
+
+        val findings = AndroidContextNotFromKoin(Config.empty).lint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `allows androidContext inside viewModel block in module`() {
+        val code = """
+            val myModule = module {
+                viewModel { MyViewModel(androidApplication()) }
+            }
+        """.trimIndent()
+
+        val findings = AndroidContextNotFromKoin(Config.empty).lint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `allows androidContext inside worker block in module`() {
+        val code = """
+            val myModule = module {
+                worker { MyWorker(androidContext()) }
+            }
+        """.trimIndent()
+
+        val findings = AndroidContextNotFromKoin(Config.empty).lint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `reports androidContext in plain class`() {
+        val code = """
+            class MyClass {
+                val ctx = androidContext()
+            }
+        """.trimIndent()
+
+        val findings = AndroidContextNotFromKoin(Config.empty).lint(code)
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `allows androidApplication inside module directly`() {
+        val code = """
+            val myModule = module {
+                androidApplication()
+            }
+        """.trimIndent()
+
+        val findings = AndroidContextNotFromKoin(Config.empty).lint(code)
+        assertThat(findings).isEmpty()
     }
 }


### PR DESCRIPTION
## Summary
- Fixed false positive where `AndroidContextNotFromKoin` rule incorrectly flagged `androidContext()` / `androidApplication()` calls inside Koin module definition blocks (`module {}`, `single {}`, `factory {}`, `scoped {}`, `viewModel {}`, `worker {}`)
- These calls are valid inside module DSL to access the Android context set up in `startKoin`
- Rule now only reports when these functions are called completely outside any Koin context

## Test plan
- [x] Tests for `androidContext()` inside all module definition types (single, factory, scoped, viewModel, worker)
- [x] Tests for `androidContext()` inside startKoin (still allowed)
- [x] Tests for `androidContext()` outside Koin context (still reported)
- [x] Full `./gradlew clean check` passes (tests + coverage 96% line / 70% branch)

Fixes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)