### PR TITLE
fix: allow one default binding alongside qualified ones

### DIFF
--- a/src/main/resources/config/config.yml
+++ b/src/main/resources/config/config.yml
@@ -37,6 +37,7 @@ koin-rules:
 
   MissingScopedDependencyQualifier:
     active: true
+    allowOneDefault: true
 
   DeprecatedKoinApi:
     active: true


### PR DESCRIPTION
## Summary
- Added `allowOneDefault` config option (default: `true`) to `MissingScopedDependencyQualifier`
- When enabled, allows the common "1 default + N qualified" binding pattern without false positive
- Only reports when 2+ unqualified definitions of the same type exist in a module
- Can be disabled with `allowOneDefault: false` to require all definitions be qualified

## Test plan
- [x] Test: 1 qualified + 1 unqualified → 0 findings (was 1, now allowed)
- [x] Test: 2 qualified + 1 unqualified → 0 findings (mixed styles, 1 default OK)
- [x] Test: 1 qualified + 2 unqualified → 1 finding (still reports)
- [x] Test: `allowOneDefault: false` config → reports 1 unqualified alongside qualified
- [x] Test: `allowOneDefault: true` config → allows 1 default
- [x] All existing duplicate detection tests still pass
- [x] `./gradlew clean check` passes (96% line / 70% branch)

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)