### PR TITLE
fix: add allowedSuperTypes to NoInjectDelegate

### DIFF
--- a/src/main/resources/config/config.yml
+++ b/src/main/resources/config/config.yml
@@ -7,6 +7,14 @@ koin-rules:
 
   NoInjectDelegate:
     active: true
+    allowedSuperTypes:
+      - 'Application'
+      - 'Activity'
+      - 'ComponentActivity'
+      - 'Fragment'
+      - 'Service'
+      - 'BroadcastReceiver'
+      - 'ViewModel'
 
   NoKoinComponentInterface:
     active: true


### PR DESCRIPTION
## Summary
- Added `allowedSuperTypes` config option to `NoInjectDelegate` (same pattern as `NoKoinComponentInterface`)
- Default allowed types: Application, Activity, ComponentActivity, Fragment, Service, BroadcastReceiver, ViewModel
- These framework classes cannot use constructor injection, so `by inject()` is the only option
- Configurable: users can customize the list or set to empty for strict mode

## Test plan
- [x] Test: inject() in Activity → 0 findings (allowed)
- [x] Test: inject() in Fragment → 0 findings (allowed)
- [x] Test: inject() in Application → 0 findings (allowed)
- [x] Test: inject() in ViewModel → 0 findings (allowed)
- [x] Test: inject() in ComponentActivity → 0 findings (allowed)
- [x] Test: inject() in Fragment with generics → 0 findings (allowed)
- [x] Test: inject() in plain class → 1 finding (still reports)
- [x] Test: custom allowedSuperTypes config (Worker) → 0 findings
- [x] Test: empty allowedSuperTypes → reports even in Activity
- [x] All existing tests still pass
- [x] `./gradlew clean check` passes (96% line / 70% branch)

Fixes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)