### PR TITLE
fix(NoGetOutsideModuleDefinition): eliminate false positives via import filter and safe-call support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,10 +43,10 @@ kover/
 docs/plans/
 
 # Detekt source files accidentally dumped to project root
-META-INF/
-io/
+/META-INF/
+/io/
 
 # Article drafts and cloned repos for PR work
 docs/article-draft.md
 docs/article-final.md
-detekt/
+/detekt/

--- a/src/main/kotlin/io/github/krozov/detekt/koin/servicelocator/NoGetOutsideModuleDefinition.kt
+++ b/src/main/kotlin/io/github/krozov/detekt/koin/servicelocator/NoGetOutsideModuleDefinition.kt
@@ -9,6 +9,8 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtSafeQualifiedExpression
 import org.jetbrains.kotlin.psi.psiUtil.getCallNameExpression
 
 internal class NoGetOutsideModuleDefinition(config: Config) : Rule(config) {
@@ -24,6 +26,16 @@ internal class NoGetOutsideModuleDefinition(config: Config) : Rule(config) {
     private var insideDefinitionBlock = false
     private val definitionFunctions = setOf("single", "factory", "scoped", "viewModel", "worker")
 
+    override fun visitKtFile(file: KtFile) {
+        insideDefinitionBlock = false
+        val hasKoinImport = file.importDirectives.any {
+            it.importedFqName?.asString()?.startsWith("org.koin") == true
+        }
+        if (hasKoinImport) {
+            super.visitKtFile(file)
+        }
+    }
+
     override fun visitCallExpression(expression: KtCallExpression) {
         val callName = expression.getCallNameExpression()?.text
 
@@ -38,10 +50,15 @@ internal class NoGetOutsideModuleDefinition(config: Config) : Rule(config) {
 
         // Check for get() calls
         if (callName in setOf("get", "getOrNull", "getAll") && !insideDefinitionBlock) {
-            // Skip qualified calls like alarmDao.getAll() -- those are method calls on arbitrary
-            // objects, not Koin service locator usage. Koin's get() is always unqualified.
-            if (expression.parent is KtDotQualifiedExpression &&
-                (expression.parent as KtDotQualifiedExpression).selectorExpression == expression) {
+            // Skip qualified calls like obj.get() or obj?.get() — those are method calls on
+            // arbitrary objects, not Koin service locator usage. Koin's get() is always unqualified.
+            val parent = expression.parent
+            val isQualified = when (parent) {
+                is KtDotQualifiedExpression -> parent.selectorExpression == expression
+                is KtSafeQualifiedExpression -> parent.selectorExpression == expression
+                else -> false
+            }
+            if (isQualified) {
                 super.visitCallExpression(expression)
                 return
             }

--- a/src/test/kotlin/io/github/krozov/detekt/koin/servicelocator/NoGetOutsideModuleDefinitionTest.kt
+++ b/src/test/kotlin/io/github/krozov/detekt/koin/servicelocator/NoGetOutsideModuleDefinitionTest.kt
@@ -102,7 +102,10 @@ class NoGetOutsideModuleDefinitionTest {
     @Test
     fun `reports get in init block`() {
         val code = """
-            class MyRepo {
+            import org.koin.core.component.KoinComponent
+            import org.koin.core.component.get
+
+            class MyRepo : KoinComponent {
                 init {
                     val service = get<ApiService>()
                 }
@@ -116,7 +119,10 @@ class NoGetOutsideModuleDefinitionTest {
     @Test
     fun `reports get in property initializer`() {
         val code = """
-            class MyRepo {
+            import org.koin.core.component.KoinComponent
+            import org.koin.core.component.get
+
+            class MyRepo : KoinComponent {
                 val service = get<ApiService>()
             }
         """.trimIndent()
@@ -128,7 +134,10 @@ class NoGetOutsideModuleDefinitionTest {
     @Test
     fun `reports get in companion object`() {
         val code = """
-            class MyRepo {
+            import org.koin.core.component.KoinComponent
+            import org.koin.core.component.get
+
+            class MyRepo : KoinComponent {
                 companion object {
                     val service = get<ApiService>()
                 }
@@ -161,5 +170,84 @@ class NoGetOutsideModuleDefinitionTest {
 
         val findings = NoGetOutsideModuleDefinition(Config.empty).lint(code)
         assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report get() in file without Koin imports`() {
+        val code = """
+            import java.util.concurrent.atomic.AtomicReference
+
+            class MyClass {
+                private val ref = AtomicReference<String>("value")
+                fun getValue() = ref.get()
+            }
+        """.trimIndent()
+
+        val findings = NoGetOutsideModuleDefinition(Config.empty).lint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report getOrNull() on Result in non-Koin file`() {
+        val code = """
+            fun process(result: Result<String>) = result.getOrNull()
+        """.trimIndent()
+
+        val findings = NoGetOutsideModuleDefinition(Config.empty).lint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report getOrNull() on List in non-Koin file`() {
+        val code = """
+            fun first(list: List<String>) = list.getOrNull(0)
+        """.trimIndent()
+
+        val findings = NoGetOutsideModuleDefinition(Config.empty).lint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report safe-qualified get call`() {
+        val code = """
+            import org.koin.core.component.KoinComponent
+
+            class MyRepository(private val cache: Cache?) : KoinComponent {
+                fun getValue() = cache?.get("key")
+            }
+        """.trimIndent()
+
+        val findings = NoGetOutsideModuleDefinition(Config.empty).lint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report safe-qualified getOrNull call`() {
+        val code = """
+            import org.koin.core.component.KoinComponent
+
+            class MyRepository(private val result: Result<String>?) : KoinComponent {
+                fun getValue() = result?.getOrNull()
+            }
+        """.trimIndent()
+
+        val findings = NoGetOutsideModuleDefinition(Config.empty).lint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `reports unqualified get() in file with Koin imports despite non-Koin qualified calls`() {
+        val code = """
+            import org.koin.core.component.KoinComponent
+            import org.koin.core.component.get
+
+            class MyRepository(private val cache: Cache) : KoinComponent {
+                val cachedValue = cache.get("key")  // qualified — safe
+                val service = get<ApiService>()      // unqualified — Koin service locator
+            }
+        """.trimIndent()
+
+        val findings = NoGetOutsideModuleDefinition(Config.empty).lint(code)
+        assertThat(findings).hasSize(1)
     }
 }


### PR DESCRIPTION
## Problem

Users reported false positives from `NoGetOutsideModuleDefinition` in several scenarios:

1. **Gradle DSL** (`.kts` files) — `get<SomeType>()` with implicit `Project` receiver — no Koin imports present
2. **`AtomicReference.get()`** — not a Koin call, but flagged
3. **`Result.getOrNull()` / `List.getOrNull()`** — standard stdlib, not Koin
4. **`obj?.get()`** (safe-call) — qualified but not covered by the existing check
5. **State leak** — `insideDefinitionBlock` was never reset between files

## Root cause

- No pre-filter: the rule processed every file regardless of Koin imports
- `KtSafeQualifiedExpression` (`?.`) was not covered by the qualified-call check (only `KtDotQualifiedExpression` was)
- `insideDefinitionBlock` was never reset between files

## Changes

### `NoGetOutsideModuleDefinition.kt`
- Add `visitKtFile()` override that resets state and **skips files without `org.koin.*` imports**
- Extend qualified-call check to cover both `obj.get()` and `obj?.get()`

### `NoGetOutsideModuleDefinitionTest.kt`
- Add 6 new test cases (non-Koin files, safe-call, mixed file)
- Update 3 existing tests to include `org.koin.*` imports (required by the new filter)

### `.gitignore`
- Anchor `io/`, `META-INF/`, `detekt/` patterns to repo root (pre-existing issue)

## Test plan

- [x] All existing tests pass
- [x] New tests cover each false-positive pattern
- [x] `./gradlew test` — all 651 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)