### PR TITLE
fix: code review follow-up — docs, field-test completeness, and minor cleanups

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -239,6 +239,7 @@ module {
 
 **Severity:** Warning
 **Active by default:** Yes
+**Configurable:** Yes
 
 Detects deprecated Koin 4.x APIs.
 
@@ -247,6 +248,19 @@ Detects deprecated Koin 4.x APIs.
 | `checkModules()` | `verify()` |
 | `koinNavViewModel()` | `koinViewModel()` |
 | `stateViewModel()` | `viewModel()` |
+
+**Configuration:**
+```yaml
+DeprecatedKoinApi:
+  active: true
+  additionalDeprecations: []
+  # Add project-specific deprecated Koin wrappers:
+  # additionalDeprecations:
+  #   - 'legacyGet:get()'
+  #   - 'oldStartKoin:startKoin()'
+```
+
+`additionalDeprecations` entries use the format `"oldName:replacement"`. Built-in entries always take precedence — you cannot override them via this parameter. Malformed entries (no colon, empty key) are silently ignored.
 
 **Edge Cases:**
 - ✅ Detects `checkModules()`, `koinNavViewModel()`, `stateViewModel()`
@@ -832,6 +846,7 @@ module {
 
 **Severity:** Warning
 **Active by default:** Yes
+**Configurable:** Yes
 
 Detects `scope.declare()` called with Activity or Fragment instances. The declared instance is never automatically cleared when the scope closes, causing the Activity/Fragment to remain referenced in memory even after it should be garbage collected.
 
@@ -859,9 +874,23 @@ class MainActivity : AppCompatActivity() {
 }
 ```
 
+**Configuration:**
+```yaml
+ScopeDeclareWithActivityOrFragment:
+  active: true
+  additionalLeakProneTypes: []
+  # Add custom base classes whose instances should not be declared in scopes:
+  # additionalLeakProneTypes:
+  #   - 'Presenter'
+  #   - 'Controller'
+```
+
+`additionalLeakProneTypes` entries are matched as **case-insensitive substrings** of the argument variable name and the containing class supertypes. For example, `"Presenter"` will flag `scope.declare(mainPresenter)` and `scope.declare(this)` inside a class extending `BasePresenter`. Choose sufficiently specific type name fragments to avoid false positives.
+
 **Edge Cases:**
 - ✅ Detects `scope.declare(activity)` and `scope.declare(fragment)` by argument name
 - ✅ Detects `scope.declare(this)` when called inside an Activity or Fragment class
+- ✅ Detects `scope.declare(this)` when called inside a class extending a configured additional type
 - ✅ Uses heuristic name matching ("activity", "fragment") and supertype checks
 
 **Related Issue:** [Koin#1122](https://github.com/InsertKoinIO/koin/issues/1122)
@@ -1742,5 +1771,133 @@ class MyService(@InjectedParam val items: List<StringList>)
 - ✅ Allows simple generics: `List<String>`
 - ✅ Allows non-generic types
 - ✅ Only checks `@InjectedParam` annotated parameters
+
+---
+
+### MissingKoinStopInTest
+
+**Severity:** Warning
+**Active by default:** Yes
+**Configurable:** Yes
+
+Detects test classes that call `startKoin` without a corresponding `stopKoin()` in an `@After` / `@AfterEach` method. Without `stopKoin()`, subsequent tests fail with `KoinApplicationAlreadyStartedException` because Koin remains started from the previous test.
+
+❌ **Bad:**
+```kotlin
+class MyTest {
+    @Before
+    fun setup() { startKoin { modules(appModule) } }
+    // No @After with stopKoin() — next test will crash
+}
+```
+
+✅ **Good:**
+```kotlin
+class MyTest {
+    @Before fun setup() { startKoin { modules(appModule) } }
+    @After fun teardown() { stopKoin() }
+}
+```
+
+**Configuration:**
+```yaml
+MissingKoinStopInTest:
+  active: true
+  additionalTeardownAnnotations: []
+  # Add project-specific teardown annotations:
+  # additionalTeardownAnnotations:
+  #   - 'CustomAfter'
+  #   - 'TearDown'
+```
+
+`additionalTeardownAnnotations` extends the built-in set (`After`, `AfterEach`, `AfterAll`) — it does not replace them.
+
+**Edge Cases:**
+- ✅ Detects JUnit 4 `@Before` / `@After`
+- ✅ Detects JUnit 5 `@BeforeEach` / `@AfterEach`
+- ✅ Detects `@AfterAll`
+- ✅ Ignores classes that do not call `startKoin`
+
+---
+
+### KoinViewModelOnNonViewModel
+
+**Severity:** Warning
+**Active by default:** Yes
+**Configurable:** Yes
+
+Detects `@KoinViewModel` annotation on classes that do not extend `ViewModel` or a recognised ViewModel base class. Koin will attempt to register the class as a ViewModel and fail at runtime.
+
+❌ **Bad:**
+```kotlin
+@KoinViewModel
+class MyPresenter  // Not a ViewModel — runtime crash
+```
+
+✅ **Good:**
+```kotlin
+@KoinViewModel
+class MyViewModel : ViewModel()
+```
+
+**Configuration:**
+```yaml
+KoinViewModelOnNonViewModel:
+  active: true
+  additionalViewModelSuperTypes: []
+  # Add custom ViewModel base classes used in your project:
+  # additionalViewModelSuperTypes:
+  #   - 'RxViewModel'
+  #   - 'BaseViewModel'
+```
+
+`additionalViewModelSuperTypes` extends the built-in heuristic (class name ends with `"ViewModel"`) with an exact-match list. Use the simple class name (no package prefix).
+
+**Edge Cases:**
+- ✅ Detects classes that do not extend any ViewModel-like base
+- ✅ Allows classes whose name ends with `"ViewModel"` (heuristic)
+- ✅ Allows classes in `additionalViewModelSuperTypes`
+- ✅ Only checks classes annotated with `@KoinViewModel`
+
+---
+
+### KoinWorkerOnNonWorker
+
+**Severity:** Warning
+**Active by default:** Yes
+**Configurable:** Yes
+
+Detects `@KoinWorker` annotation on classes that do not extend `Worker` or a recognised Worker base class. Koin will attempt to register the class as a Worker and fail at runtime.
+
+❌ **Bad:**
+```kotlin
+@KoinWorker
+class MyTask  // Not a Worker — runtime crash
+```
+
+✅ **Good:**
+```kotlin
+@KoinWorker
+class MyWorker : CoroutineWorker(context, params)
+```
+
+**Configuration:**
+```yaml
+KoinWorkerOnNonWorker:
+  active: true
+  additionalWorkerSuperTypes: []
+  # Add custom Worker base classes used in your project:
+  # additionalWorkerSuperTypes:
+  #   - 'BaseWorker'
+  #   - 'RxWorker'
+```
+
+`additionalWorkerSuperTypes` extends the built-in heuristic (class name ends with `"Worker"`) with an exact-match list. Use the simple class name (no package prefix).
+
+**Edge Cases:**
+- ✅ Detects classes that do not extend any Worker-like base
+- ✅ Allows classes whose name ends with `"Worker"` (heuristic)
+- ✅ Allows classes in `additionalWorkerSuperTypes`
+- ✅ Only checks classes annotated with `@KoinWorker`
 
 ---

--- a/scripts/field-test/detekt-koin-all-rules.yml
+++ b/scripts/field-test/detekt-koin-all-rules.yml
@@ -71,8 +71,10 @@ koin-rules:
     allowOneDefault: true  # Allow one unqualified definition per scope
 
   # Detects deprecated Koin API usage.
+  # additionalDeprecations: add project-specific deprecated wrappers (format: "oldName:replacement")
   DeprecatedKoinApi:
     active: true
+    additionalDeprecations: []
 
   # Detects modules that mix includes() with definitions — prefer separation.
   # Inactive by default (style rule).
@@ -150,9 +152,11 @@ koin-rules:
   KtorRequestScopeMisuse:
     active: true
 
-  # Detects scope {} declared with Activity or Fragment as scope qualifier.
+  # Detects scope.declare() called with Activity/Fragment instances (memory leak).
+  # additionalLeakProneTypes: add custom base classes to detect (substring match, case-insensitive)
   ScopeDeclareWithActivityOrFragment:
     active: true
+    additionalLeakProneTypes: []
 
   # ---------------------------------------------------------------------------
   # Platform — Android
@@ -235,6 +239,24 @@ koin-rules:
   # ---------------------------------------------------------------------------
   # Koin Annotations
   # ---------------------------------------------------------------------------
+
+  # Detects test classes that call startKoin without stopKoin() in @After/@AfterEach.
+  # additionalTeardownAnnotations: extend built-in set (After, AfterEach, AfterAll)
+  MissingKoinStopInTest:
+    active: true
+    additionalTeardownAnnotations: []
+
+  # Detects @KoinViewModel on classes that do not extend ViewModel.
+  # additionalViewModelSuperTypes: add custom ViewModel base classes (exact simple name match)
+  KoinViewModelOnNonViewModel:
+    active: true
+    additionalViewModelSuperTypes: []
+
+  # Detects @KoinWorker on classes that do not extend Worker.
+  # additionalWorkerSuperTypes: add custom Worker base classes (exact simple name match)
+  KoinWorkerOnNonWorker:
+    active: true
+    additionalWorkerSuperTypes: []
 
   # Detects mixing of DSL module() {} and @Module annotation in the same project.
   MixingDslAndAnnotations:

--- a/src/main/kotlin/io/github/krozov/detekt/koin/annotations/MissingKoinStopInTest.kt
+++ b/src/main/kotlin/io/github/krozov/detekt/koin/annotations/MissingKoinStopInTest.kt
@@ -43,8 +43,8 @@ public class MissingKoinStopInTest(config: Config = Config.empty) : Rule(config)
     private val additionalTeardownAnnotations: List<String> =
         config.value(key = "additionalTeardownAnnotations", default = emptyList())
 
-    private val teardownAnnotations: List<String> =
-        listOf("After", "AfterEach", "AfterAll") + additionalTeardownAnnotations
+    private val teardownAnnotations: Set<String> =
+        (listOf("After", "AfterEach", "AfterAll") + additionalTeardownAnnotations).toSet()
 
     override fun visitClass(klass: KtClass) {
         super.visitClass(klass)

--- a/src/test/kotlin/io/github/krozov/detekt/koin/moduledsl/DeprecatedKoinApiTest.kt
+++ b/src/test/kotlin/io/github/krozov/detekt/koin/moduledsl/DeprecatedKoinApiTest.kt
@@ -394,4 +394,32 @@ class DeprecatedKoinApiTest {
         val findings = DeprecatedKoinApi(Config.empty).lint(code)
         assertThat(findings).isEmpty()
     }
+
+    @Test
+    fun `silently ignores malformed additionalDeprecations entry without colon`() {
+        val code = """
+            fun test() {
+                legacyGet()
+            }
+        """.trimIndent()
+
+        // Entry without ":" separator — should be silently dropped, not crash
+        val config = TestConfig("additionalDeprecations" to listOf("legacyGetWithoutReplacement"))
+        val findings = DeprecatedKoinApi(config).lint(code)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `silently ignores malformed additionalDeprecations entry with empty key`() {
+        val code = """
+            fun test() {
+                legacyGet()
+            }
+        """.trimIndent()
+
+        // Entry with empty key (":replacement") — should be silently dropped
+        val config = TestConfig("additionalDeprecations" to listOf(":get()"))
+        val findings = DeprecatedKoinApi(config).lint(code)
+        assertThat(findings).isEmpty()
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up to PRs #75 and #76, addressing issues found in post-merge code review.

- **`docs/rules.md`**: add `**Configurable:** Yes` markers and `Configuration:` YAML blocks to `DeprecatedKoinApi` and `ScopeDeclareWithActivityOrFragment`; add full entries for `MissingKoinStopInTest`, `KoinViewModelOnNonViewModel`, `KoinWorkerOnNonWorker` (all three were entirely absent)
- **`scripts/field-test/detekt-koin-all-rules.yml`**: add all 5 new configurable parameters and the 3 missing Koin Annotations rules — file claimed to be "complete configuration" but was not
- **`MissingKoinStopInTest`**: change `teardownAnnotations` from `List<String>` to `Set<String>` to prevent duplicate entries when `additionalTeardownAnnotations` overlaps with built-ins
- **`DeprecatedKoinApiTest`**: add 2 tests documenting the silent-drop contract for malformed `additionalDeprecations` entries (no colon, empty key)

## Test plan

- [ ] `./gradlew check` passes (build + all tests + detekt self-analysis + coverage)
- [ ] `docs/rules.md` has Configuration blocks for all 5 new parameters
- [ ] `scripts/field-test/detekt-koin-all-rules.yml` lists all annotation rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)