### PR TITLE
feat(annotations): add ScopedBindsHasNoEffect rule

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,6 +1,6 @@
 # Koin Rules Documentation
 
-Complete reference for all 51 Detekt rules for Koin.
+Complete reference for all 57 Detekt rules for Koin.
 
 ---
 
@@ -1899,5 +1899,43 @@ KoinWorkerOnNonWorker:
 - ✅ Allows classes whose name ends with `"Worker"` (heuristic)
 - ✅ Allows classes in `additionalWorkerSuperTypes`
 - ✅ Only checks classes annotated with `@KoinWorker`
+
+---
+
+### ScopedBindsHasNoEffect
+
+**Severity:** Warning
+**Active by default:** Yes
+
+Detects `@Scoped(binds = [...])` which has no effect.
+
+Unlike `@Single` and `@Factory`, the `@Scoped` annotation does not support the `binds` parameter.
+Koin Annotations silently ignores `binds=` on `@Scoped` — the binding is never registered at runtime.
+This creates a silent no-op bug that's hard to diagnose.
+
+❌ **Bad:**
+```kotlin
+interface MyInterface
+
+@Scoped(binds = [MyInterface::class])
+class MyService : MyInterface
+// binds= is silently ignored — MyInterface is NOT bound
+```
+
+✅ **Good:**
+```kotlin
+// Option 1: Use @Single if you need interface binding
+@Single(binds = [MyInterface::class])
+class MyService : MyInterface
+
+// Option 2: Use @Scoped without binds (binds to own class only)
+@Scoped
+class MyService : MyInterface
+```
+
+**Edge Cases:**
+- ✅ Reports `@Scoped(binds = [...])` regardless of how many types are listed
+- ✅ Does not report `@Scoped` without the `binds` parameter
+- ✅ Does not report `@Single(binds = [...])` or `@Factory(binds = [...])`
 
 ---

--- a/src/main/kotlin/io/github/krozov/detekt/koin/KoinRuleSetProvider.kt
+++ b/src/main/kotlin/io/github/krozov/detekt/koin/KoinRuleSetProvider.kt
@@ -65,6 +65,7 @@ import io.github.krozov.detekt.koin.annotations.KoinViewModelOnNonViewModel
 import io.github.krozov.detekt.koin.annotations.MissingKoinStopInTest
 import io.github.krozov.detekt.koin.annotations.InjectedParamAnnotationOrder
 import io.github.krozov.detekt.koin.annotations.KoinWorkerOnNonWorker
+import io.github.krozov.detekt.koin.annotations.ScopedBindsHasNoEffect
 
 public class KoinRuleSetProvider : RuleSetProvider {
 
@@ -139,7 +140,8 @@ public class KoinRuleSetProvider : RuleSetProvider {
                 KoinViewModelOnNonViewModel(config),
                 MissingKoinStopInTest(config),
                 InjectedParamAnnotationOrder(config),
-                KoinWorkerOnNonWorker(config)
+                KoinWorkerOnNonWorker(config),
+                ScopedBindsHasNoEffect(config)
             )
         )
     }

--- a/src/main/kotlin/io/github/krozov/detekt/koin/annotations/ScopedBindsHasNoEffect.kt
+++ b/src/main/kotlin/io/github/krozov/detekt/koin/annotations/ScopedBindsHasNoEffect.kt
@@ -1,0 +1,66 @@
+package io.github.krozov.detekt.koin.annotations
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtClass
+
+/**
+ * Detects `@Scoped(binds = [...])` which has no effect.
+ *
+ * Unlike `@Single` and `@Factory`, `@Scoped` does not support the `binds` parameter.
+ * Koin Annotations silently ignores `binds` on `@Scoped`, so the binding is never registered.
+ *
+ * <noncompliant>
+ * @Scoped(binds = [MyInterface::class])
+ * class MyService : MyInterface
+ * </noncompliant>
+ *
+ * <compliant>
+ * @Single(binds = [MyInterface::class])
+ * class MyService : MyInterface
+ *
+ * // Or use @Scoped without binds:
+ * @Scoped
+ * class MyService : MyInterface
+ * </compliant>
+ */
+public class ScopedBindsHasNoEffect(config: Config = Config.empty) : Rule(config) {
+    override val issue: Issue = Issue(
+        id = "ScopedBindsHasNoEffect",
+        severity = Severity.Warning,
+        description = "@Scoped(binds = [...]) has no effect — @Scoped does not support the binds parameter",
+        debt = Debt.FIVE_MINS
+    )
+
+    override fun visitClass(klass: KtClass) {
+        super.visitClass(klass)
+
+        val scopedAnnotation = klass.annotationEntries
+            .find { it.shortName?.asString() == "Scoped" } ?: return
+
+        val hasBindsParam = scopedAnnotation.valueArgumentList?.arguments
+            ?.any { it.getArgumentName()?.asName?.asString() == "binds" } == true
+
+        if (hasBindsParam) {
+            report(
+                CodeSmell(
+                    issue,
+                    Entity.from(scopedAnnotation),
+                    """
+                    @Scoped(binds = [...]) has no effect — @Scoped does not support the binds parameter
+                    → Koin Annotations silently ignores binds= on @Scoped
+                    → Use @Single(binds = [...]) if you need interface binding, or remove binds=
+
+                    ✗ Bad:  @Scoped(binds = [MyInterface::class]) class ${klass.name ?: "MyClass"} : MyInterface
+                    ✓ Good: @Single(binds = [MyInterface::class]) class ${klass.name ?: "MyClass"} : MyInterface
+                    """.trimIndent()
+                )
+            )
+        }
+    }
+}

--- a/src/main/resources/config/config.yml
+++ b/src/main/resources/config/config.yml
@@ -162,3 +162,6 @@ koin-rules:
   KoinWorkerOnNonWorker:
     active: true
     additionalWorkerSuperTypes: []
+
+  ScopedBindsHasNoEffect:
+    active: true

--- a/src/test/kotlin/io/github/krozov/detekt/koin/KoinRuleSetProviderTest.kt
+++ b/src/test/kotlin/io/github/krozov/detekt/koin/KoinRuleSetProviderTest.kt
@@ -18,6 +18,6 @@ class KoinRuleSetProviderTest {
         val ruleSet = provider.instance(config)
 
         assertThat(ruleSet.rules).isNotEmpty()
-        assertThat(ruleSet.rules).hasSize(56)
+        assertThat(ruleSet.rules).hasSize(57)
     }
 }

--- a/src/test/kotlin/io/github/krozov/detekt/koin/annotations/ScopedBindsHasNoEffectTest.kt
+++ b/src/test/kotlin/io/github/krozov/detekt/koin/annotations/ScopedBindsHasNoEffectTest.kt
@@ -1,0 +1,89 @@
+package io.github.krozov.detekt.koin.annotations
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ScopedBindsHasNoEffectTest {
+
+    @Test
+    fun `reports Scoped with binds parameter`() {
+        val code = """
+            import org.koin.core.annotation.Scoped
+
+            interface MyInterface
+
+            @Scoped(binds = [MyInterface::class])
+            class MyService : MyInterface
+        """.trimIndent()
+
+        val findings = ScopedBindsHasNoEffect(Config.empty).lint(code)
+
+        assertThat(findings).hasSize(1)
+        assertThat(findings[0].message).contains("binds")
+    }
+
+    @Test
+    fun `does not report Scoped without binds parameter`() {
+        val code = """
+            import org.koin.core.annotation.Scoped
+
+            @Scoped
+            class MyService
+        """.trimIndent()
+
+        val findings = ScopedBindsHasNoEffect(Config.empty).lint(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report Single with binds parameter`() {
+        val code = """
+            import org.koin.core.annotation.Single
+
+            interface MyInterface
+
+            @Single(binds = [MyInterface::class])
+            class MyService : MyInterface
+        """.trimIndent()
+
+        val findings = ScopedBindsHasNoEffect(Config.empty).lint(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `does not report Factory with binds parameter`() {
+        val code = """
+            import org.koin.core.annotation.Factory
+
+            interface MyInterface
+
+            @Factory(binds = [MyInterface::class])
+            class MyService : MyInterface
+        """.trimIndent()
+
+        val findings = ScopedBindsHasNoEffect(Config.empty).lint(code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `reports Scoped with binds containing multiple classes`() {
+        val code = """
+            import org.koin.core.annotation.Scoped
+
+            interface InterfaceA
+            interface InterfaceB
+
+            @Scoped(binds = [InterfaceA::class, InterfaceB::class])
+            class MyService : InterfaceA, InterfaceB
+        """.trimIndent()
+
+        val findings = ScopedBindsHasNoEffect(Config.empty).lint(code)
+
+        assertThat(findings).hasSize(1)
+    }
+}

--- a/src/test/kotlin/io/github/krozov/detekt/koin/integration/KoinRulesIntegrationTest.kt
+++ b/src/test/kotlin/io/github/krozov/detekt/koin/integration/KoinRulesIntegrationTest.kt
@@ -28,7 +28,7 @@ class KoinRulesIntegrationTest {
         val ruleSet = koinProvider!!.instance(Config.empty)
 
         assertThat(ruleSet.id).isEqualTo("koin-rules")
-        assertThat(ruleSet.rules).hasSize(56)
+        assertThat(ruleSet.rules).hasSize(57)
 
         // Verify all rule names
         val ruleIds = ruleSet.rules.map { it.ruleId }
@@ -98,7 +98,8 @@ class KoinRulesIntegrationTest {
             "KoinViewModelOnNonViewModel",
             "MissingKoinStopInTest",
             "InjectedParamAnnotationOrder",
-            "SingleOnAbstractClass"
+            "SingleOnAbstractClass",
+            "ScopedBindsHasNoEffect"
         )
     }
 


### PR DESCRIPTION
## Summary

Adds `ScopedBindsHasNoEffect` rule that detects `@Scoped(binds = [...])` annotations which have no effect at runtime.

## Problem

`@Scoped` in Koin Annotations does **not** support the `binds` parameter, unlike `@Single` and `@Factory`. When `binds=` is specified on `@Scoped`, Koin silently ignores it — the interface binding is never registered. This creates a subtle bug that's hard to diagnose since there's no runtime error.

## Detection

The rule visits class declarations and checks if any class annotated with `@Scoped` has the `binds` argument in its annotation.

## Fix suggestion

The rule message guides users to either:
1. Switch to `@Single(binds = [...])` if interface binding is needed
2. Remove the `binds` parameter from `@Scoped`

## Test plan

- [x] Reports `@Scoped(binds = [MyInterface::class])`
- [x] Does not report `@Scoped` without `binds`
- [x] Does not report `@Single(binds = [...])` or `@Factory(binds = [...])`
- [x] `./gradlew check` passes

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)