### PR TITLE
fix(servicelocator): fix resolveTypeFqn for generic types, add missing tests

### DIFF
--- a/src/main/kotlin/io/github/krozov/detekt/koin/servicelocator/PreferLazyConstructorInjection.kt
+++ b/src/main/kotlin/io/github/krozov/detekt/koin/servicelocator/PreferLazyConstructorInjection.kt
@@ -53,19 +53,22 @@ internal class PreferLazyConstructorInjection(config: Config) : Rule(config) {
             if (rawType.startsWith("(")) return@forEach
 
             val isNullable = rawType.endsWith("?")
-            val shortName = rawType.removeSuffix("?").trim()
-            val lazyType = if (isNullable) "Lazy<$shortName?>" else "Lazy<$shortName>"
-            val resolvedFqn = resolveTypeFqn(shortName, file)
+            // Full type text without trailing '?' — may include generic arguments, e.g. "Map<String, Int>"
+            val typeText = rawType.removeSuffix("?").trim()
+            // Outer type name without generics — used for import lookup and entry matching
+            val baseName = typeText.substringBefore("<")
+            val lazyType = if (isNullable) "Lazy<$typeText?>" else "Lazy<$typeText>"
+            val resolvedFqn = resolveTypeFqn(baseName, file)
 
-            if (isExcluded(resolvedFqn, shortName)) return@forEach
-            if (!shouldFlag(resolvedFqn, shortName)) return@forEach
+            if (isExcluded(resolvedFqn, typeText)) return@forEach
+            if (!shouldFlag(resolvedFqn, typeText)) return@forEach
 
             report(
                 CodeSmell(
                     issue,
                     Entity.from(param),
                     """
-                    $shortName injected eagerly → consider $lazyType for deferred resolution
+                    $typeText injected eagerly → consider $lazyType for deferred resolution
 
                     ✗ Current:  ${param.text}
                     ✓ Preferred: ${param.text.replace(rawType, lazyType)}
@@ -78,29 +81,38 @@ internal class PreferLazyConstructorInjection(config: Config) : Rule(config) {
         }
     }
 
-    private fun resolveTypeFqn(shortName: String, file: KtFile): String? {
-        if (shortName.contains('.')) return shortName
+    /**
+     * Resolves [baseName] (outer type name, no generics) to a fully-qualified name via import
+     * directives. Returns the FQN string if resolved, or `null` when unresolvable (e.g. star
+     * import, no import at all). When [baseName] already contains a dot it is treated as inline FQN.
+     *
+     * **Known limitation — import aliases:** `import com.example.Foo as Bar` is not handled;
+     * a parameter typed as `Bar` will not be matched against a `com.example.Foo` config entry.
+     */
+    private fun resolveTypeFqn(baseName: String, file: KtFile): String? {
+        if (baseName.contains('.')) return baseName
         return file.importDirectives
             .mapNotNull { it.importedFqName?.asString() }
-            .firstOrNull { it.substringAfterLast('.') == shortName }
+            .firstOrNull { it.substringAfterLast('.') == baseName }
     }
 
-    private fun isExcluded(fqn: String?, shortName: String): Boolean =
-        excludeTypes.any { entry -> matchesEntry(entry, fqn, shortName) }
+    // typeText — full type text without '?', may include generics, e.g. "Map<String, Int>"
+    private fun isExcluded(fqn: String?, typeText: String): Boolean =
+        excludeTypes.any { entry -> matchesEntry(entry, fqn, typeText) }
 
-    private fun shouldFlag(fqn: String?, shortName: String): Boolean {
+    private fun shouldFlag(fqn: String?, typeText: String): Boolean {
         if (checkAllTypes) return true
-        return lazyTypes.any { entry -> matchesEntry(entry, fqn, shortName) }
+        return lazyTypes.any { entry -> matchesEntry(entry, fqn, typeText) }
     }
 
-    private fun matchesEntry(entry: String, fqn: String?, shortName: String): Boolean {
-        val baseShortName = shortName.substringBefore("<")
+    private fun matchesEntry(entry: String, fqn: String?, typeText: String): Boolean {
+        val baseName = typeText.substringBefore("<")
         val normalizedFqn = fqn?.substringBefore("<")
         return if (entry.contains('.')) {
             val entryShortName = entry.substringAfterLast('.')
-            normalizedFqn == entry || (normalizedFqn == null && (shortName == entryShortName || baseShortName == entryShortName))
+            normalizedFqn == entry || (normalizedFqn == null && (typeText == entryShortName || baseName == entryShortName))
         } else {
-            shortName == entry || baseShortName == entry
+            typeText == entry || baseName == entry
         }
     }
 }

--- a/src/test/kotlin/io/github/krozov/detekt/koin/servicelocator/PreferLazyConstructorInjectionTest.kt
+++ b/src/test/kotlin/io/github/krozov/detekt/koin/servicelocator/PreferLazyConstructorInjectionTest.kt
@@ -89,6 +89,15 @@ class PreferLazyConstructorInjectionTest {
         }
 
         @Test
+        fun `does not flag nullable Lazy type`() {
+            val findings = PreferLazyConstructorInjection(config).lint("""
+                class MyRepo(private val db: Lazy<DatabaseClient>?)
+            """.trimIndent())
+
+            assertThat(findings).isEmpty()
+        }
+
+        @Test
         fun `flags nullable type that matches lazyTypes`() {
             val findings = PreferLazyConstructorInjection(config).lint("""
                 class MyRepo(private val db: DatabaseClient?)
@@ -210,6 +219,20 @@ class PreferLazyConstructorInjectionTest {
             """.trimIndent())
 
             assertThat(findings).hasSize(3)
+        }
+
+        @Test
+        fun `flags types not in lazyTypes when checkAllTypes overrides it`() {
+            val configWithBoth = TestConfig(
+                "checkAllTypes" to true,
+                "lazyTypes" to listOf("DatabaseClient")
+            )
+
+            val findings = PreferLazyConstructorInjection(configWithBoth).lint("""
+                class MyRepo(private val api: HttpClient)
+            """.trimIndent())
+
+            assertThat(findings).hasSize(1)
         }
     }
 
@@ -436,6 +459,36 @@ class PreferLazyConstructorInjectionTest {
                 import com.example.DatabaseClient
 
                 class MyRepo(private val db: DatabaseClient)
+            """.trimIndent())
+
+            assertThat(findings).isEmpty()
+        }
+
+        @Test
+        fun `flags generic type whose outer name resolves to configured FQN via import`() {
+            val config = TestConfig(
+                "lazyTypes" to listOf("com.example.db.DatabaseClient")
+            )
+
+            val findings = PreferLazyConstructorInjection(config).lint("""
+                import com.example.db.DatabaseClient
+
+                class MyRepo(private val dbs: DatabaseClient<String>)
+            """.trimIndent())
+
+            assertThat(findings).hasSize(1)
+        }
+
+        @Test
+        fun `does not flag generic type when outer name resolves to different package`() {
+            val config = TestConfig(
+                "lazyTypes" to listOf("com.example.db.DatabaseClient")
+            )
+
+            val findings = PreferLazyConstructorInjection(config).lint("""
+                import com.other.DatabaseClient
+
+                class MyRepo(private val dbs: DatabaseClient<String>)
             """.trimIndent())
 
             assertThat(findings).isEmpty()


### PR DESCRIPTION
## Summary

Follow-up fixes to \`PreferLazyConstructorInjection\` after PR #83 review.

### Bug fix — \`resolveTypeFqn\` breaks for generic types

**Before:** \`resolveTypeFqn("Map<String, Int>", file)\` searched for an import whose last segment equals \`"Map<String, Int>"\` — impossible to match. FQN config entries like \`"kotlin.collections.Map"\` silently failed to resolve for generic parameters.

**After:** Outer type name is stripped of generics before import lookup (\`baseName = typeText.substringBefore("<")\`), so import resolution works correctly for any generic type.

### Naming clarity

Renamed local variable \`shortName\` → \`typeText\` / \`baseName\` to reflect that the de-nulled type text *may contain generic arguments* (e.g. \`"Map<String, Int>"\`), while \`baseName\` is the unambiguous outer type name used for lookups.

Added KDoc on \`resolveTypeFqn\` documenting the alias-import limitation.

> **Note:** Migrating to \`FileImportContext\` (added in #83) to also support alias imports is intentionally deferred — that is a larger refactor tracked separately.

### New tests (4)

- \`does not flag nullable Lazy<T>?\` (LazyTypesAllowlist)
- \`flags types not in lazyTypes when checkAllTypes overrides it\` (CheckAllTypes)
- \`flags generic type whose outer name resolves to configured FQN via import\` (FqnMatching)
- \`does not flag generic type when outer name resolves to different package\` (FqnMatching)

## Checklist

- [x] Bug fixed with test coverage
- [x] \`./gradlew check\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)